### PR TITLE
Fix trait type input

### DIFF
--- a/website/src/components/DropdownFilter.tsx
+++ b/website/src/components/DropdownFilter.tsx
@@ -1,8 +1,8 @@
-import { MenuItem, TextField } from "@material-ui/core";
-import React from "react"
+import React from 'react'
 
 export interface Option {
-  value: string, label: string
+  value: string
+  label: string
 }
 interface Props {
   options: Option[]
@@ -12,31 +12,30 @@ interface Props {
   className?: string
 }
 export const DropdownFilter = (props: Props) => {
-  const {options, setFilterValue, filterValue, label, className} = props;
+  const { options, setFilterValue, filterValue, label } = props
 
   const optionElems = options.map((option, index) => (
-    <MenuItem key={index} value={option.value}>{option.label}</MenuItem>
+    <option key={index} value={option.value}>
+      {option.label}
+    </option>
   ))
-  const effectiveValue = (filterValue === undefined) ? "" : filterValue
+  const effectiveValue = filterValue === undefined ? '' : filterValue
   return (
-      <TextField
-        select={true}
-        fullWidth={true}
-        label={label}
+    <>
+      <label>{label}</label>
+
+      <select
+        style={{ height: 30 }}
+        name={label}
+        id={label}
         value={effectiveValue}
-        SelectProps={{
-          displayEmpty: true,
-          renderValue: value => {return (value === "") ? value : options.find(option => option.value === value)!.label},
-        }}
-        onChange={e => {
-          const newValue = (e.target.value === "") ? undefined : e.target.value
+        onChange={(e) => {
+          const newValue = e.target.value === '' ? undefined : e.target.value
           setFilterValue(newValue)
         }}
-        className={className}
       >
-        <MenuItem value="">All</MenuItem>
         {optionElems}
-      </TextField>
+      </select>
+    </>
   )
 }
-

--- a/website/src/pages/phenotypes.tsx
+++ b/website/src/pages/phenotypes.tsx
@@ -4,8 +4,8 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import {  PhenotypesPageContentWrapper } from "../components/PhenotypesPageContentWrapper";
 import {  docusaurusLayoutWrapperClassName } from "../components/PhenotypesPageContent";
 
+import "regenerator-runtime/runtime.js";
 import "core-js/stable";
-import "regenerator-runtime/runtime";
 
 const Phenotypes = () => {
   const context = useDocusaurusContext()


### PR DESCRIPTION
The trait type input element doesn't render the options correctly (bug in MaterialUI?).

![image](https://user-images.githubusercontent.com/8867295/115739841-4717e880-a35c-11eb-861d-e38c96187020.png)

This PR changes input elements to vanilla HTML inputs:

![image](https://user-images.githubusercontent.com/8867295/115739931-5a2ab880-a35c-11eb-84fc-0322719318c6.png)
