### PR TITLE
Updated meta-analysis

### DIFF
--- a/resources/results.py
+++ b/resources/results.py
@@ -17,8 +17,9 @@ def get_variant_results_qc_path(extension: str = 'ht'):
     return f'{public_bucket_free}/sumstats_qc_analysis/full_variant_qc_metrics.{extension}'
 
 
-def get_meta_analysis_results_path(extension: str = 'mt'):
-    return f'{public_bucket}/sumstats_release/meta_analysis.{extension}'
+def get_meta_analysis_results_path(filter_pheno_h2_qc: bool = True, extension: str = 'mt'):
+    qc = 'h2_qc' if filter_pheno_h2_qc else 'raw'
+    return f'{public_bucket}/sumstats_release/meta_analysis.{qc}.{extension}'
 
 
 def get_phenotype_results_qc_path(extension: str = 'ht'):

--- a/run_meta_analysis.py
+++ b/run_meta_analysis.py
@@ -30,9 +30,10 @@ def main(args):
     # Read in all sumstats
     mt = load_final_sumstats_mt(filter_phenos=True,
                                 filter_variants=False,
-                                filter_sumstats=True,
+                                filter_sumstats=(not args.keep_low_confidence_variants),
                                 separate_columns_by_pop=False,
-                                annotate_with_nearest_gene=False)
+                                annotate_with_nearest_gene=False,
+                                filter_pheno_h2_qc=(not args.keep_low_heritability_pairs))
 
     # Annotate per-entry sample size
     def get_n(pheno_data, i):
@@ -40,11 +41,7 @@ def main(args):
 
     mt = mt.annotate_entries(
         summary_stats=hl.map(lambda x: x[1].annotate(N=hl.or_missing(hl.is_defined(x[1]), get_n(mt.pheno_data, x[0]))),
-                             hl.zip_with_index(mt.summary_stats)))
-
-    # Exclude entries with low confidence flag.
-    if not args.keep_low_confidence_variants:
-        mt = mt.annotate_entries(summary_stats=hl.map(lambda x: hl.or_missing(~x.low_confidence, x), mt.summary_stats))
+                             hl.enumerate(mt.summary_stats)))
 
     # Run fixed-effect meta-analysis (all + leave-one-out)
     mt = mt.annotate_entries(unnorm_beta=mt.summary_stats.BETA / (mt.summary_stats.SE**2),
@@ -53,13 +50,13 @@ def main(args):
                              sum_inv_se2=all_and_leave_one_out(mt.inv_se2, mt.pheno_data.pop))
     mt = mt.transmute_entries(META_BETA=mt.sum_unnorm_beta / mt.sum_inv_se2,
                               META_SE=hl.map(lambda x: hl.sqrt(1 / x), mt.sum_inv_se2))
-    mt = mt.annotate_entries(META_Pvalue=hl.map(lambda x: 2 * hl.pnorm(x), -hl.abs(mt.META_BETA / mt.META_SE)))
+    mt = mt.annotate_entries(META_Pvalue=hl.map(lambda x: 2 * hl.pnorm(x, log_p=True), -hl.abs(mt.META_BETA / mt.META_SE)))
 
     # Run heterogeneity test (Cochran's Q)
     mt = mt.annotate_entries(META_Q=hl.map(lambda x: hl.sum((mt.summary_stats.BETA - x)**2 * mt.inv_se2), mt.META_BETA),
                              variant_exists=hl.map(lambda x: ~hl.is_missing(x), mt.summary_stats.BETA))
     mt = mt.annotate_entries(META_N_pops=all_and_leave_one_out(mt.variant_exists, mt.pheno_data.pop))
-    mt = mt.annotate_entries(META_Pvalue_het=hl.map(lambda i: hl.pchisqtail(mt.META_Q[i], mt.META_N_pops[i] - 1),
+    mt = mt.annotate_entries(META_Pvalue_het=hl.map(lambda i: hl.pchisqtail(mt.META_Q[i], mt.META_N_pops[i] - 1, log_p=True),
                                                     hl.range(hl.len(mt.META_Q))))
 
     # Add other annotations
@@ -97,7 +94,7 @@ def main(args):
         lambda i: hl.struct(**{field: mt[field][i] for field in col_fields}), hl.range(hl.len(mt.pop))))
 
     mt.describe()
-    mt.write(get_meta_analysis_results_path(), overwrite=args.overwrite)
+    mt.write(get_meta_analysis_results_path(filter_pheno_h2_qc=(not args.keep_low_heritability_pairs)), overwrite=args.overwrite)
 
     hl.copy_log('gs://ukb-diverse-pops/combined_results/meta_analysis.log')
 
@@ -106,6 +103,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--keep-low-confidence-variants',
                         help='Keep variants with low confidence flag for meta-analysis',
+                        action='store_true')
+    parser.add_argument('--keep-low-heritability-pairs',
+                        help='Keep trait-ancestry pairs that failed at heritability QC',
                         action='store_true')
     parser.add_argument('--overwrite', help='Overwrite data', action='store_true')
     args = parser.parse_args()

--- a/utils/results.py
+++ b/utils/results.py
@@ -46,7 +46,7 @@ def load_final_sumstats_mt(filter_phenos: bool = True, filter_variants: bool = T
     mt = mt.drop('heritability', 'paired_pop_h2')
 
     if filter_phenos:
-        keep_phenos = hl.zip_with_index(mt.pheno_data).filter(
+        keep_phenos = hl.enumerate(mt.pheno_data).filter(
             lambda x: filter_lambda_gc(x[1].lambda_gc))
 
         mt = mt.annotate_cols(
@@ -95,7 +95,7 @@ def load_final_sumstats_mt(filter_phenos: bool = True, filter_variants: bool = T
 
 
 def separate_results_mt_by_pop(mt, col_field = 'pheno_data', entry_field = 'summary_stats', skip_drop: bool = False):
-    mt = mt.annotate_cols(col_array=hl.zip_with_index(mt[col_field])).explode_cols('col_array')
+    mt = mt.annotate_cols(col_array=hl.enumerate(mt[col_field])).explode_cols('col_array')
     mt = mt.transmute_cols(pop_index=mt.col_array[0], **{col_field: mt.col_array[1]})
     mt = mt.annotate_entries(**{entry_field: mt[entry_field][mt.pop_index]})
     if not skip_drop:


### PR DESCRIPTION
* I reran meta-analysis with and without @rahulg603's heritability filter (only keeping QC-passing trait-ancestry pairs)
* meta P-values are now log (ln)-transformed, same as the latest sumstats mt
* New results are available at: `get_meta_analysis_results_path(filter_pheno_h2_qc=[True/False])` or `gs://ukb-diverse-pops-public/sumstats_release/meta_analysis.{h2_qc,raw}.mt`
  * No. phenos before/after QC: 7,220 and 524